### PR TITLE
Adding Persistence to Scaffold DbContext Dialog

### DIFF
--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/cli/api/DbContextCommandFactory.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/cli/api/DbContextCommandFactory.kt
@@ -13,7 +13,7 @@ class DbContextCommandFactory(intellijProject: Project) : BaseCommandFactory(int
     fun scaffold(efCoreVersion: DotnetEfVersion, options: CommonOptions, connection: String, provider: String,
                  outputFolder: String, useAttributes: Boolean, useDatabaseNames: Boolean, generateOnConfiguring: Boolean,
                  usePluralizer: Boolean, dbContextName: String, dbContextFolder: String, scaffoldAllTables: Boolean,
-                 tablesList: List<String>, scaffoldAllSchemas: Boolean, schemasList: List<String>): CliCommand =
+                 tablesList: List<String>, scaffoldAllSchemas: Boolean, schemasList: List<String>, forceOverride: Boolean): CliCommand =
         createCommand(KnownEfCommands.DbContext.scaffold, options) {
             add(connection)
             add(provider)
@@ -21,7 +21,7 @@ class DbContextCommandFactory(intellijProject: Project) : BaseCommandFactory(int
             addIf("--data-annotations", useAttributes)
             addNamed("--context", dbContextName)
             addNamed("--context-dir", dbContextFolder)
-            //addIf("--force", force)
+            addIf("--force", forceOverride)
             addNamed("--output-dir", outputFolder)
 
             if (!scaffoldAllSchemas) {

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextModel.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/dbcontext/scaffold/ScaffoldDbContextModel.kt
@@ -19,5 +19,7 @@ data class ScaffoldDbContextModel(
     val schemasList: MutableList<SimpleItem>,
 
     var scaffoldAllTables: Boolean,
-    var scaffoldAllSchemas: Boolean
+    var scaffoldAllSchemas: Boolean,
+
+    var overrideExisting: Boolean
 )

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/shared/services/PreferredProjectsManager.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/shared/services/PreferredProjectsManager.kt
@@ -2,6 +2,7 @@ package me.seclerp.rider.plugins.efcore.features.shared.services
 
 import com.intellij.openapi.project.Project
 import me.seclerp.rider.plugins.efcore.state.CommonOptionsStateService
+import me.seclerp.rider.plugins.efcore.state.DbScaffoldOptionsStateService
 import me.seclerp.rider.plugins.efcore.ui.items.MigrationsProjectItem
 import me.seclerp.rider.plugins.efcore.ui.items.StartupProjectItem
 import java.util.*
@@ -10,6 +11,7 @@ class PreferredProjectsManager(
     intellijProject: Project
 ) {
     private val commonOptionsStateService = CommonOptionsStateService.getInstance(intellijProject)
+    private val dbScaffoldOptionsStateService = DbScaffoldOptionsStateService.getInstance(intellijProject)
     private var prevPreferredMigrationsProjectId: UUID? = null
     private var prevPreferredStartupProjectId: UUID? = null
 
@@ -68,6 +70,22 @@ class PreferredProjectsManager(
 
     fun setGlobalProjectPair(migrationsProjectItem: MigrationsProjectItem, startupProjectItem: StartupProjectItem) {
         commonOptionsStateService.setGlobalProjectIdsPair(migrationsProjectItem.data.id, startupProjectItem.data.id)
+    }
+
+     fun getScaffoldString(fieldName: String): String{
+        return dbScaffoldOptionsStateService.getOptionString(fieldName)
+    }
+
+    fun setScaffoldString(fieldName: String, value: String){
+        dbScaffoldOptionsStateService.setOptionString(fieldName, value)
+    }
+
+    fun getScaffoldBoolean(fieldName: String): Boolean{
+        return dbScaffoldOptionsStateService.getOptionBoolean(fieldName)
+    }
+
+    fun setScaffoldBoolean(fieldName: String, value: Boolean){
+        dbScaffoldOptionsStateService.setOptionBoolean(fieldName, value)
     }
 
     private fun getDefaultProjects(preferredProjectId: UUID?, migrationsProjects: Array<MigrationsProjectItem>,

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/state/DbScaffoldOptionsState.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/state/DbScaffoldOptionsState.kt
@@ -1,0 +1,5 @@
+package me.seclerp.rider.plugins.efcore.state
+
+class DbScaffoldOptionsState {
+    var solutionLevelOptions: MutableMap<String, String> = mutableMapOf()
+} 

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/state/DbScaffoldOptionsStateService.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/state/DbScaffoldOptionsStateService.kt
@@ -1,0 +1,39 @@
+package me.seclerp.rider.plugins.efcore.state
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.project.Project
+
+@Service
+@State(name = "EfCoreDbScaffoldOptions", storages = [Storage("efCoreDbScaffoldOptions.xml")])
+class DbScaffoldOptionsStateService: PersistentStateComponent<DbScaffoldOptionsState> {
+    private var myState = DbScaffoldOptionsState()
+
+    override fun getState(): DbScaffoldOptionsState = myState
+
+    override fun loadState(state: DbScaffoldOptionsState) {
+        myState = state
+    }
+
+    fun setOptionString(fieldName: String, value: String) {
+        myState.solutionLevelOptions[fieldName] = value
+    }
+
+    fun setOptionBoolean(fieldName: String, value: Boolean){
+        myState.solutionLevelOptions[fieldName] = value.toString()
+    }
+
+    fun getOptionString(fieldName: String): String {
+
+        return myState.solutionLevelOptions[fieldName] ?: return ""
+    }
+
+    fun getOptionBoolean(fieldName: String): Boolean {
+
+        return myState.solutionLevelOptions[fieldName].toBoolean()
+    }
+
+    companion object {
+        fun getInstance(project: Project) = project.service<DbScaffoldOptionsStateService>()
+
+    }
+} 


### PR DESCRIPTION
Changes allow for persistence of the DbContext fields between reloads. Support mentioned in https://github.com/seclerp/rider-efcore/issues/54. Once entered and OK is pressed, values are saved for the next scaffolding. Build option was shared between dialog screens, so that was untouched.