### PR TITLE
Add .NET Standard 2.0 support for migration projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ More about features and available dialogs you could read in [**the blog post**](
   - `net6.0`
   - `net5.0`
   - `netcoreapp3.1`
+  - `netstandard2.0` (only for Migrations projects)
   - `netstandard2.1` (only for Migrations projects)
 
 

--- a/src/dotnet/Rider.Plugins.EfCore/Compatibility/SupportedTargetFrameworks.cs
+++ b/src/dotnet/Rider.Plugins.EfCore/Compatibility/SupportedTargetFrameworks.cs
@@ -6,6 +6,7 @@
         public const string Net6 = "net6.0";
         public const string Net7 = "net7.0";
         public const string NetCore31 = ".NETCoreApp,Version=v3.1";
+        public const string NetStandard20 = ".NETStandard,Version=v2.0";
         public const string NetStandard21 = ".NETStandard,Version=v2.1";
     }
 }

--- a/src/dotnet/Rider.Plugins.EfCore/Compatibility/TargetFrameworkIdExtensions.cs
+++ b/src/dotnet/Rider.Plugins.EfCore/Compatibility/TargetFrameworkIdExtensions.cs
@@ -9,6 +9,7 @@ namespace Rider.Plugins.EfCore.Compatibility
             || targetFrameworkId.UniqueString.StartsWith(SupportedTargetFrameworks.Net6)
             || targetFrameworkId.UniqueString.StartsWith(SupportedTargetFrameworks.Net7)
             || targetFrameworkId.UniqueString.StartsWith(SupportedTargetFrameworks.NetCore31)
+            || targetFrameworkId.UniqueString.StartsWith(SupportedTargetFrameworks.NetStandard20)
             || targetFrameworkId.UniqueString.StartsWith(SupportedTargetFrameworks.NetStandard21);
 
         public static bool IsSupportedInStartupProject(this TargetFrameworkId targetFrameworkId) =>


### PR DESCRIPTION
Some project running EF Core version 3.1.x are using migrations projects using the .NET Standard 2.0 SDK (which is supported by the latest release of EF Core 3.1)